### PR TITLE
Fix case in meta image paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,14 @@
     <meta property="og:url" content="https://www.happyaipath.com/">
     <meta property="og:title" content="Happy AI Path | Executive AI Coaching and Team Training">
     <meta property="og:description" content="Expert AI coaching and training for executives and teams. Gain confidence, clarity, and a strategic edge with guidance from a seasoned Fortune 100 technology leader.">
-    <meta property="og:image" content="happyaipath.png">
+    <meta property="og:image" content="HappyAIPath.png">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Happy AI Path | Executive AI Coaching and Team Training">
     <meta name="twitter:description" content="Expert AI coaching and training for executives and teams. Gain confidence, clarity, and a strategic edge with guidance from a seasoned Fortune 100 technology leader.">
-    <meta name="twitter:image" content="happyaipath.png">
+    <meta name="twitter:image" content="HappyAIPath.png">
 
-    <link rel="icon" href="happyaipath.png" type="image/png">
+    <link rel="icon" href="HappyAIPath.png" type="image/png">
     
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
 


### PR DESCRIPTION
## Summary
- fix the filename casing for HappyAIPath.png

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687935f48b78832c84746ea50cfe7937