### PR TITLE
Add Google gtag snippet to all HTML pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -84,6 +84,15 @@
       ]
     }
     </script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/blog-post-template.html
+++ b/blog-post-template.html
@@ -115,6 +115,15 @@
         #backToTopBtn { display: none; position: fixed; bottom: 20px; right: 30px; z-index: 99; border: none; outline: none; background-color: #4f46e5; color: white; cursor: pointer; padding: 12px; border-radius: 50%; box-shadow: 0 4px 12px rgba(0,0,0,0.2); transition: opacity 0.3s, visibility 0.3s; }
         #backToTopBtn:hover { background-color: #4338ca; }
     </style>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="bg-white text-gray-800">
     <!-- Skip to main content for accessibility -->

--- a/blog.html
+++ b/blog.html
@@ -26,6 +26,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="styles.css">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/contact.html
+++ b/contact.html
@@ -26,6 +26,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="styles.css">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/events.html
+++ b/events.html
@@ -26,6 +26,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="styles.css">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/guide.html
+++ b/guide.html
@@ -41,6 +41,15 @@
         #backToTopBtn { display: none; position: fixed; bottom: 20px; right: 30px; z-index: 99; border: none; outline: none; background-color: #4f46e5; color: white; cursor: pointer; padding: 12px; border-radius: 50%; box-shadow: 0 4px 12px rgba(0,0,0,0.2); transition: opacity 0.3s, visibility 0.3s; }
         #backToTopBtn:hover { background-color: #4338ca; }
     </style>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="absolute top-[-40px] left-0 bg-indigo-600 text-white p-2 z-50 focus:top-0 transition-all">Skip to main content</a>

--- a/index.html
+++ b/index.html
@@ -173,6 +173,15 @@
           .ai-bubble { animation: none !important; }
         }
     </style>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 
 <body class="bg-white text-gray-800">

--- a/quiz.html
+++ b/quiz.html
@@ -33,6 +33,15 @@
         #backToTopBtn { display: none; position: fixed; bottom: 20px; right: 30px; z-index: 99; border: none; outline: none; background-color: #4f46e5; color: white; cursor: pointer; padding: 12px; border-radius: 50%; box-shadow: 0 4px 12px rgba(0,0,0,0.2); transition: opacity 0.3s, visibility 0.3s; }
         #backToTopBtn:hover { background-color: #4338ca; }
     </style>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="absolute top-[-40px] left-0 bg-indigo-600 text-white p-2 z-50 focus:top-0 transition-all">Skip to main content</a>

--- a/services.html
+++ b/services.html
@@ -23,6 +23,15 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="styles.css">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/tips.html
+++ b/tips.html
@@ -98,6 +98,15 @@
             font-weight: 600;
         }
     </style>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-T4QRVGGY9L');
+</script>
 </head>
 <body class="antialiased">
 


### PR DESCRIPTION
### Motivation
- Add site-wide Google Analytics tracking by inserting the provided `gtag.js` snippet (measurement ID `G-T4QRVGGY9L`) into every HTML page so analytics loads consistently from each page.

### Description
- Inserted the supplied Google tag snippet (async loader `https://www.googletagmanager.com/gtag/js?id=G-T4QRVGGY9L`, `window.dataLayer` bootstrapping, and `gtag('config', 'G-T4QRVGGY9L')`) immediately before `</head>` in the site HTML files `about.html`, `blog-post-template.html`, `blog.html`, `contact.html`, `events.html`, `guide.html`, `index.html`, `quiz.html`, `services.html`, and `tips.html`.
- Changes were limited to adding the snippet and did not alter other page content or layout.

### Testing
- Ran a presence check with `for f in *.html; do grep -q 'G-T4QRVGGY9L' "$f" || echo "missing $f"; done` and confirmed every `*.html` file contains the measurement ID (success).
- Ran a local href validation script (`python - <<'PY' ... PY`) which reported unresolved template/parent-relative links in `blog-post-template.html`; these are preexisting template placeholders and unrelated to the tag insertion (issue observed, not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cdfdea04832c8a2f57e3709475f2)