### PR TITLE
Add WebPage JSON-LD structured data to remaining HTML pages

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -35,6 +35,31 @@
 
   gtag('config', 'G-T4QRVGGY9L');
 </script>
+
+    <!-- Structured Data - WebPage -->
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Happy AI Path Blog | AI Insights and Strategies",
+  "description": "Explore insights, strategies, and practical tips for confident AI adoption on the Happy AI Path blog. Your journey to AI fluency starts here.",
+  "url": "https://www.happyaipath.com/blog.html",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.happyaipath.com/HappyAIPath.png"
+    }
+  }
+}
+    </script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/contact.html
+++ b/contact.html
@@ -35,6 +35,31 @@
 
   gtag('config', 'G-T4QRVGGY9L');
 </script>
+
+    <!-- Structured Data - WebPage -->
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Contact Us | Happy AI Path",
+  "description": "Schedule a complimentary consultation with AI expert Jim Perry. Let's discuss your AI training and executive coaching needs.",
+  "url": "https://www.happyaipath.com/contact.html",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.happyaipath.com/HappyAIPath.png"
+    }
+  }
+}
+    </script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/events.html
+++ b/events.html
@@ -35,6 +35,31 @@
 
   gtag('config', 'G-T4QRVGGY9L');
 </script>
+
+    <!-- Structured Data - WebPage -->
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Upcoming AI Events and Workshops | Happy AI Path",
+  "description": "Join Jim Perry for upcoming AI workshops, webinars, and training sessions. See the schedule and register for events at The Ohio State University and online.",
+  "url": "https://www.happyaipath.com/events.html",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.happyaipath.com/HappyAIPath.png"
+    }
+  }
+}
+    </script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>

--- a/guide.html
+++ b/guide.html
@@ -50,6 +50,31 @@
 
   gtag('config', 'G-T4QRVGGY9L');
 </script>
+
+    <!-- Structured Data - WebPage -->
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "AI Website Playbook | Happy AI Path",
+  "description": "A complete, AI-powered playbook for building and launching a professional website for \u2248$20 with zero prior experience.",
+  "url": "https://www.happyaipath.com/guide.html",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.happyaipath.com/HappyAIPath.png"
+    }
+  }
+}
+    </script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="absolute top-[-40px] left-0 bg-indigo-600 text-white p-2 z-50 focus:top-0 transition-all">Skip to main content</a>

--- a/quiz.html
+++ b/quiz.html
@@ -42,6 +42,31 @@
 
   gtag('config', 'G-T4QRVGGY9L');
 </script>
+
+    <!-- Structured Data - WebPage -->
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "AI Readiness Quiz | Happy AI Path",
+  "description": "Take our 2-minute AI Readiness Quiz to assess your organization's preparedness for AI adoption and identify key areas for growth.",
+  "url": "https://www.happyaipath.com/quiz.html",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.happyaipath.com/HappyAIPath.png"
+    }
+  }
+}
+    </script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="absolute top-[-40px] left-0 bg-indigo-600 text-white p-2 z-50 focus:top-0 transition-all">Skip to main content</a>

--- a/services.html
+++ b/services.html
@@ -32,6 +32,31 @@
 
   gtag('config', 'G-T4QRVGGY9L');
 </script>
+
+    <!-- Structured Data - WebPage -->
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "AI Training and Executive Coaching Services | Happy AI Path",
+  "description": "Explore our Corporate AI Training and Executive Coaching services. We empower teams and leaders to master AI and drive business growth.",
+  "url": "https://www.happyaipath.com/services.html",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Happy AI Path",
+    "url": "https://www.happyaipath.com/",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.happyaipath.com/HappyAIPath.png"
+    }
+  }
+}
+    </script>
 </head>
 <body class="bg-white text-gray-800">
     <a href="#main-content" class="skip-link">Skip to main content</a>


### PR DESCRIPTION
### Motivation
- Ensure every site page exposes JSON-LD so search engines and agents can consistently parse page metadata for improved SEO and rich result eligibility.
- Fill gaps where pages lacked structured data while keeping schema consistent across the site.

### Description
- Added `application/ld+json` `WebPage` schema blocks into the `<head>` of `blog.html`, `contact.html`, `events.html`, `guide.html`, `quiz.html`, and `services.html`.
- Each JSON-LD block includes page-specific `name`, `description`, and canonical `url` plus shared `isPartOf` (`WebSite`) and `publisher` (`Organization` with `logo`) entries for consistent metadata.
- Inserted the script blocks immediately before `</head>` so they are available to crawlers early in page parsing.

### Testing
- Ran a presence check with `for f in *.html; do if rg -q "application/ld\+json" "$f"; then :; else echo "missing $f"; fi; done` and confirmed no HTML pages are missing a JSON-LD block after the changes (success).
- Ran `python scripts/check_links.py` and it reported pre-existing placeholder/broken links inside `blog-post-template.html` (failure), which are unrelated to these JSON-LD additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc97d66b70832c9b4cedac36cf8691)