### PR TITLE
Standardize site URLs to non-www and add canonical/robots metadata

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,18 +8,18 @@
     <meta name="keywords" content="Jim Perry, AI Expert, Executive AI Coach, AI Speaker, Technology Leader, Ohio State University">
     <meta name="author" content="Jim Perry, Happy AI Path">
     <meta name="robots" content="index, follow">
-    <link rel="canonical" href="https://www.happyaipath.com/about.html">
+    <link rel="canonical" href="https://happyaipath.com/about.html">
 
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.happyaipath.com/about.html">
+    <meta property="og:url" content="https://happyaipath.com/about.html">
     <meta property="og:title" content="About Jim Perry | Happy AI Path">
     <meta property="og:description" content="Learn about Jim Perry, a seasoned technology leader and Adjunct Lecturer at The Ohio State University, and his mission to demystify AI for business.">
-    <meta property="og:image" content="https://www.happyaipath.com/DSC00498%20(Small).jpg">
+    <meta property="og:image" content="https://happyaipath.com/DSC00498%20(Small).jpg">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="About Jim Perry | Happy AI Path">
     <meta name="twitter:description" content="Learn about Jim Perry, a seasoned technology leader and Adjunct Lecturer at The Ohio State University, and his mission to demystify AI for business.">
-    <meta name="twitter:image" content="https://www.happyaipath.com/DSC00498%20(Small).jpg">
+    <meta name="twitter:image" content="https://happyaipath.com/DSC00498%20(Small).jpg">
 
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
@@ -37,13 +37,13 @@
       "name": "Jim Perry",
       "jobTitle": "AI Coach and Technology Leader",
       "description": "Seasoned technology leader with over 20 years of experience leading business transformation for Fortune 100 companies. Adjunct Lecturer at The Ohio State University Fisher College of Business.",
-      "url": "https://www.happyaipath.com/about.html",
-      "image": "https://www.happyaipath.com/DSC00498%20(Small).jpg",
+      "url": "https://happyaipath.com/about.html",
+      "image": "https://happyaipath.com/DSC00498%20(Small).jpg",
       "worksFor": [
         {
           "@type": "Organization",
           "name": "Happy AI Path",
-          "url": "https://www.happyaipath.com"
+          "url": "https://happyaipath.com"
         },
         {
           "@type": "Organization",

--- a/blog-post-template.html
+++ b/blog-post-template.html
@@ -15,14 +15,14 @@
     <meta name="article:modified_time" content="[YYYY-MM-DD]">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://www.happyaipath.com/blog/[blog-post-slug].html">
+    <link rel="canonical" href="https://happyaipath.com/blog/[blog-post-slug].html">
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://www.happyaipath.com/blog/[blog-post-slug].html">
+    <meta property="og:url" content="https://happyaipath.com/blog/[blog-post-slug].html">
     <meta property="og:title" content="[Blog Post Title]">
     <meta property="og:description" content="[Blog post description]">
-    <meta property="og:image" content="https://www.happyaipath.com/images/blog/[blog-post-image].jpg">
+    <meta property="og:image" content="https://happyaipath.com/images/blog/[blog-post-image].jpg">
     <meta property="og:site_name" content="Happy AI Path">
     <meta property="article:author" content="Jim Perry">
     <meta property="article:section" content="AI Strategy">
@@ -30,10 +30,10 @@
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://www.happyaipath.com/blog/[blog-post-slug].html">
+    <meta property="twitter:url" content="https://happyaipath.com/blog/[blog-post-slug].html">
     <meta property="twitter:title" content="[Blog Post Title]">
     <meta property="twitter:description" content="[Blog post description]">
-    <meta property="twitter:image" content="https://www.happyaipath.com/images/blog/[blog-post-image].jpg">
+    <meta property="twitter:image" content="https://happyaipath.com/images/blog/[blog-post-image].jpg">
     
     <!-- Favicon -->
     <link rel="icon" href="../HappyAIPath.png" type="image/png">
@@ -50,25 +50,25 @@
       "@type": "Article",
       "headline": "[Blog Post Title]",
       "description": "[Blog post description]",
-      "image": "https://www.happyaipath.com/images/blog/[blog-post-image].jpg",
+      "image": "https://happyaipath.com/images/blog/[blog-post-image].jpg",
       "author": {
         "@type": "Person",
         "name": "Jim Perry",
-        "url": "https://www.happyaipath.com/about.html"
+        "url": "https://happyaipath.com/about.html"
       },
       "publisher": {
         "@type": "Organization",
         "name": "Happy AI Path",
         "logo": {
           "@type": "ImageObject",
-          "url": "https://www.happyaipath.com/HappyAIPath.png"
+          "url": "https://happyaipath.com/HappyAIPath.png"
         }
       },
       "datePublished": "[YYYY-MM-DD]",
       "dateModified": "[YYYY-MM-DD]",
       "mainEntityOfPage": {
         "@type": "WebPage",
-        "@id": "https://www.happyaipath.com/blog/[blog-post-slug].html"
+        "@id": "https://happyaipath.com/blog/[blog-post-slug].html"
       },
       "articleSection": "AI Strategy",
       "keywords": "[keyword1, keyword2, keyword3]"

--- a/blog.html
+++ b/blog.html
@@ -3,21 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
     <title>Happy AI Path Blog | AI Insights and Strategies</title>
+    <link rel="canonical" href="https://happyaipath.com/blog.html">
     <meta name="description" content="Explore insights, strategies, and practical tips for confident AI adoption on the Happy AI Path blog. Your journey to AI fluency starts here.">
     <meta name="keywords" content="AI Blog, AI Strategy, Business AI, AI Adoption, Prompt Engineering Tips, AI Leadership">
     <meta name="author" content="Jim Perry, Happy AI Path">
 
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.happyaipath.com/blog.html">
+    <meta property="og:url" content="https://happyaipath.com/blog.html">
     <meta property="og:title" content="Happy AI Path Blog | AI Insights and Strategies">
     <meta property="og:description" content="Explore insights, strategies, and practical tips for confident AI adoption on the Happy AI Path blog. Your journey to AI fluency starts here.">
-    <meta property="og:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta property="og:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Happy AI Path Blog | AI Insights and Strategies">
     <meta name="twitter:description" content="Explore insights, strategies, and practical tips for confident AI adoption on the Happy AI Path blog. Your journey to AI fluency starts here.">
-    <meta name="twitter:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta name="twitter:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
@@ -43,19 +45,19 @@
   "@type": "WebPage",
   "name": "Happy AI Path Blog | AI Insights and Strategies",
   "description": "Explore insights, strategies, and practical tips for confident AI adoption on the Happy AI Path blog. Your journey to AI fluency starts here.",
-  "url": "https://www.happyaipath.com/blog.html",
+  "url": "https://happyaipath.com/blog.html",
   "isPartOf": {
     "@type": "WebSite",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/"
+    "url": "https://happyaipath.com/"
   },
   "publisher": {
     "@type": "Organization",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/",
+    "url": "https://happyaipath.com/",
     "logo": {
       "@type": "ImageObject",
-      "url": "https://www.happyaipath.com/HappyAIPath.png"
+      "url": "https://happyaipath.com/HappyAIPath.png"
     }
   }
 }

--- a/contact.html
+++ b/contact.html
@@ -3,21 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
     <title>Contact Us | Happy AI Path</title>
+    <link rel="canonical" href="https://happyaipath.com/contact.html">
     <meta name="description" content="Schedule a complimentary consultation with AI expert Jim Perry. Let's discuss your AI training and executive coaching needs.">
     <meta name="keywords" content="Contact AI Coach, AI Consultation, Schedule AI Training, AI Expert Contact">
     <meta name="author" content="Jim Perry, Happy AI Path">
 
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.happyaipath.com/contact.html">
+    <meta property="og:url" content="https://happyaipath.com/contact.html">
     <meta property="og:title" content="Contact Us | Happy AI Path">
     <meta property="og:description" content="Schedule a complimentary consultation with AI expert Jim Perry. Let's discuss your AI training and executive coaching needs.">
-    <meta property="og:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta property="og:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Contact Us | Happy AI Path">
     <meta name="twitter:description" content="Schedule a complimentary consultation with AI expert Jim Perry. Let's discuss your AI training and executive coaching needs.">
-    <meta name="twitter:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta name="twitter:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
@@ -43,19 +45,19 @@
   "@type": "WebPage",
   "name": "Contact Us | Happy AI Path",
   "description": "Schedule a complimentary consultation with AI expert Jim Perry. Let's discuss your AI training and executive coaching needs.",
-  "url": "https://www.happyaipath.com/contact.html",
+  "url": "https://happyaipath.com/contact.html",
   "isPartOf": {
     "@type": "WebSite",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/"
+    "url": "https://happyaipath.com/"
   },
   "publisher": {
     "@type": "Organization",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/",
+    "url": "https://happyaipath.com/",
     "logo": {
       "@type": "ImageObject",
-      "url": "https://www.happyaipath.com/HappyAIPath.png"
+      "url": "https://happyaipath.com/HappyAIPath.png"
     }
   }
 }

--- a/events.html
+++ b/events.html
@@ -3,21 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
     <title>Upcoming AI Events and Workshops | Happy AI Path</title>
+    <link rel="canonical" href="https://happyaipath.com/events.html">
     <meta name="description" content="Join Jim Perry for upcoming AI workshops, webinars, and training sessions. See the schedule and register for events at The Ohio State University and online.">
     <meta name="keywords" content="AI Events, AI Workshops, AI Training, Prompt Engineering Workshop, AI Webinars, Ohio State University AI">
     <meta name="author" content="Jim Perry, Happy AI Path">
 
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.happyaipath.com/events.html">
+    <meta property="og:url" content="https://happyaipath.com/events.html">
     <meta property="og:title" content="Upcoming AI Events and Workshops | Happy AI Path">
     <meta property="og:description" content="Join Jim Perry for upcoming AI workshops, webinars, and training sessions. See the schedule and register for events at The Ohio State University and online.">
-    <meta property="og:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta property="og:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Upcoming AI Events and Workshops | Happy AI Path">
     <meta name="twitter:description" content="Join Jim Perry for upcoming AI workshops, webinars, and training sessions. See the schedule and register for events at The Ohio State University and online.">
-    <meta name="twitter:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta name="twitter:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
@@ -43,19 +45,19 @@
   "@type": "WebPage",
   "name": "Upcoming AI Events and Workshops | Happy AI Path",
   "description": "Join Jim Perry for upcoming AI workshops, webinars, and training sessions. See the schedule and register for events at The Ohio State University and online.",
-  "url": "https://www.happyaipath.com/events.html",
+  "url": "https://happyaipath.com/events.html",
   "isPartOf": {
     "@type": "WebSite",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/"
+    "url": "https://happyaipath.com/"
   },
   "publisher": {
     "@type": "Organization",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/",
+    "url": "https://happyaipath.com/",
     "logo": {
       "@type": "ImageObject",
-      "url": "https://www.happyaipath.com/HappyAIPath.png"
+      "url": "https://happyaipath.com/HappyAIPath.png"
     }
   }
 }

--- a/guide.html
+++ b/guide.html
@@ -3,21 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
     <title>AI Website Playbook | Happy AI Path</title>
+    <link rel="canonical" href="https://happyaipath.com/guide.html">
     <meta name="description" content="A complete, AI-powered playbook for building and launching a professional website for ≈$20 with zero prior experience.">
     <meta name="keywords" content="AI Website Builder, Build a Website with AI, AI Web Design, Free Website Guide, AI Playbook">
     <meta name="author" content="Jim Perry, Happy AI Path">
 
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://www.happyaipath.com/guide.html">
+    <meta property="og:url" content="https://happyaipath.com/guide.html">
     <meta property="og:title" content="AI Website Playbook | Happy AI Path">
     <meta property="og:description" content="A complete, AI-powered playbook for building and launching a professional website for ≈$20 with zero prior experience.">
-    <meta property="og:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta property="og:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Website Playbook | Happy AI Path">
     <meta name="twitter:description" content="A complete, AI-powered playbook for building and launching a professional website for ≈$20 with zero prior experience.">
-    <meta name="twitter:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta name="twitter:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
@@ -58,19 +60,19 @@
   "@type": "WebPage",
   "name": "AI Website Playbook | Happy AI Path",
   "description": "A complete, AI-powered playbook for building and launching a professional website for \u2248$20 with zero prior experience.",
-  "url": "https://www.happyaipath.com/guide.html",
+  "url": "https://happyaipath.com/guide.html",
   "isPartOf": {
     "@type": "WebSite",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/"
+    "url": "https://happyaipath.com/"
   },
   "publisher": {
     "@type": "Organization",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/",
+    "url": "https://happyaipath.com/",
     "logo": {
       "@type": "ImageObject",
-      "url": "https://www.happyaipath.com/HappyAIPath.png"
+      "url": "https://happyaipath.com/HappyAIPath.png"
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -8,18 +8,18 @@
     <meta name="keywords" content="Executive AI Coaching, AI Team Training, AI Adoption, AI Strategy, AI Leadership, Prompt Engineering, AI Readiness Quiz">
     <meta name="author" content="Jim Perry, Happy AI Path">
     <meta name="robots" content="index, follow">
-    <link rel="canonical" href="https://www.happyaipath.com/">
+    <link rel="canonical" href="https://happyaipath.com/">
 
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.happyaipath.com/">
+    <meta property="og:url" content="https://happyaipath.com/">
     <meta property="og:title" content="Happy AI Path | Executive AI Coaching and Team Training">
     <meta property="og:description" content="Expert AI coaching and training for executives and teams. Gain confidence, clarity, and a strategic edge with guidance from a seasoned Fortune 100 technology leader.">
-    <meta property="og:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta property="og:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Happy AI Path | Executive AI Coaching and Team Training">
     <meta name="twitter:description" content="Expert AI coaching and training for executives and teams. Gain confidence, clarity, and a strategic edge with guidance from a seasoned Fortune 100 technology leader.">
-    <meta name="twitter:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta name="twitter:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
@@ -35,8 +35,8 @@
       "@context": "https://schema.org",
       "@type": "Organization",
       "name": "Happy AI Path",
-      "url": "https://www.happyaipath.com",
-      "logo": "https://www.happyaipath.com/HappyAIPath.png",
+      "url": "https://happyaipath.com",
+      "logo": "https://happyaipath.com/HappyAIPath.png",
       "description": "Expert AI coaching and training for executives and teams. Gain confidence, clarity, and a strategic edge with guidance from a seasoned Fortune 100 technology leader.",
       "founder": {
         "@type": "Person",
@@ -56,7 +56,7 @@
       "contactPoint": {
         "@type": "ContactPoint",
         "contactType": "customer service",
-        "url": "https://www.happyaipath.com/contact.html"
+        "url": "https://happyaipath.com/contact.html"
       },
       "sameAs": [
         "https://www.linkedin.com/company/happyaipath",

--- a/llms.txt
+++ b/llms.txt
@@ -8,9 +8,9 @@
 > technology leadership to every engagement.
 
 ## Services
-- [AI Team Training](https://www.happyaipath.com/services.html#team-training)
-- [Executive AI Coaching](https://www.happyaipath.com/services.html#executive-coaching)
-- [AI Prompting Lab](https://www.happyaipath.com/tips.html): Free library of high-impact prompt templates for executives, strategy, productivity, and team management.
+- [AI Team Training](https://happyaipath.com/services.html#team-training)
+- [Executive AI Coaching](https://happyaipath.com/services.html#executive-coaching)
+- [AI Prompting Lab](https://happyaipath.com/tips.html): Free library of high-impact prompt templates for executives, strategy, productivity, and team management.
 
 ## Credentials
 - Based in Columbus, Ohio — serving clients locally and nationally
@@ -26,12 +26,12 @@
 - [LinkedIn Profile & Recommendations](https://www.linkedin.com/in/jimperry)
 
 ## Live Content
-- [Blog — AI Insights and Strategies](https://www.happyaipath.com/blog.html): Practical posts on AI adoption, Copilot, ChatGPT, and enterprise AI strategy. Updated regularly.
+- [Blog — AI Insights and Strategies](https://happyaipath.com/blog.html): Practical posts on AI adoption, Copilot, ChatGPT, and enterprise AI strategy. Updated regularly.
 
 ## Contact
-- [Schedule a Consultation](https://www.happyaipath.com/contact.html)
-- [Upcoming Events & Workshops](https://www.happyaipath.com/events.html)
+- [Schedule a Consultation](https://happyaipath.com/contact.html)
+- [Upcoming Events & Workshops](https://happyaipath.com/events.html)
 
 ## Optional
-- [Home](https://www.happyaipath.com/)
-- [AI Website Playbook](https://www.happyaipath.com/guide.html)
+- [Home](https://happyaipath.com/)
+- [AI Website Playbook](https://happyaipath.com/guide.html)

--- a/quiz.html
+++ b/quiz.html
@@ -3,21 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
     <title>AI Readiness Quiz | Happy AI Path</title>
+    <link rel="canonical" href="https://happyaipath.com/quiz.html">
     <meta name="description" content="Take our 2-minute AI Readiness Quiz to assess your organization's preparedness for AI adoption and identify key areas for growth.">
     <meta name="keywords" content="AI Readiness Quiz, AI Assessment, AI for Business, Organizational AI, AI Strategy Quiz">
     <meta name="author" content="Jim Perry, Happy AI Path">
 
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.happyaipath.com/quiz.html">
+    <meta property="og:url" content="https://happyaipath.com/quiz.html">
     <meta property="og:title" content="AI Readiness Quiz | Happy AI Path">
     <meta property="og:description" content="Take our 2-minute AI Readiness Quiz to assess your organization's preparedness for AI adoption and identify key areas for growth.">
-    <meta property="og:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta property="og:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Readiness Quiz | Happy AI Path">
     <meta name="twitter:description" content="Take our 2-minute AI Readiness Quiz to assess your organization's preparedness for AI adoption and identify key areas for growth.">
-    <meta name="twitter:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta name="twitter:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
@@ -50,19 +52,19 @@
   "@type": "WebPage",
   "name": "AI Readiness Quiz | Happy AI Path",
   "description": "Take our 2-minute AI Readiness Quiz to assess your organization's preparedness for AI adoption and identify key areas for growth.",
-  "url": "https://www.happyaipath.com/quiz.html",
+  "url": "https://happyaipath.com/quiz.html",
   "isPartOf": {
     "@type": "WebSite",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/"
+    "url": "https://happyaipath.com/"
   },
   "publisher": {
     "@type": "Organization",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/",
+    "url": "https://happyaipath.com/",
     "logo": {
       "@type": "ImageObject",
-      "url": "https://www.happyaipath.com/HappyAIPath.png"
+      "url": "https://happyaipath.com/HappyAIPath.png"
     }
   }
 }

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.happyaipath.com/sitemap.xml
+Sitemap: https://happyaipath.com/sitemap.xml

--- a/services.html
+++ b/services.html
@@ -3,19 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="index, follow">
     <title>AI Training and Executive Coaching Services | Happy AI Path</title>
+    <link rel="canonical" href="https://happyaipath.com/services.html">
     <meta name="description" content="Explore our Corporate AI Training and Executive Coaching services. We empower teams and leaders to master AI and drive business growth.">
     <meta name="keywords" content="Executive AI Coaching, AI Team Training, AI Adoption, AI Strategy, AI Leadership, Prompt Engineering, AI Readiness Quiz">
     <meta name="author" content="Jim Perry, Happy AI Path">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://www.happyaipath.com/services.html">
+    <meta property="og:url" content="https://happyaipath.com/services.html">
     <meta property="og:title" content="AI Training and Executive Coaching Services | Happy AI Path">
     <meta property="og:description" content="Explore our Corporate AI Training and Executive Coaching services. We empower teams and leaders to master AI and drive business growth.">
-    <meta property="og:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta property="og:image" content="https://happyaipath.com/HappyAIPath.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="AI Training and Executive Coaching Services | Happy AI Path">
     <meta name="twitter:description" content="Explore our Corporate AI Training and Executive Coaching services. We empower teams and leaders to master AI and drive business growth.">
-    <meta name="twitter:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta name="twitter:image" content="https://happyaipath.com/HappyAIPath.png">
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preload" as="image" href="HappyAIPath.svg" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -40,19 +42,19 @@
   "@type": "WebPage",
   "name": "AI Training and Executive Coaching Services | Happy AI Path",
   "description": "Explore our Corporate AI Training and Executive Coaching services. We empower teams and leaders to master AI and drive business growth.",
-  "url": "https://www.happyaipath.com/services.html",
+  "url": "https://happyaipath.com/services.html",
   "isPartOf": {
     "@type": "WebSite",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/"
+    "url": "https://happyaipath.com/"
   },
   "publisher": {
     "@type": "Organization",
     "name": "Happy AI Path",
-    "url": "https://www.happyaipath.com/",
+    "url": "https://happyaipath.com/",
     "logo": {
       "@type": "ImageObject",
-      "url": "https://www.happyaipath.com/HappyAIPath.png"
+      "url": "https://happyaipath.com/HappyAIPath.png"
     }
   }
 }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,55 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.happyaipath.com/</loc>
+    <loc>https://happyaipath.com/</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.happyaipath.com/services.html</loc>
+    <loc>https://happyaipath.com/services.html</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://www.happyaipath.com/about.html</loc>
+    <loc>https://happyaipath.com/about.html</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.happyaipath.com/blog.html</loc>
+    <loc>https://happyaipath.com/blog.html</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.happyaipath.com/tips.html</loc>
+    <loc>https://happyaipath.com/tips.html</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.happyaipath.com/contact.html</loc>
+    <loc>https://happyaipath.com/contact.html</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.happyaipath.com/guide.html</loc>
+    <loc>https://happyaipath.com/guide.html</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.happyaipath.com/events.html</loc>
+    <loc>https://happyaipath.com/events.html</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://www.happyaipath.com/quiz.html</loc>
+    <loc>https://happyaipath.com/quiz.html</loc>
     <lastmod>2025-10-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/tips.html
+++ b/tips.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Prompting Lab | High-Impact Templates & Tips - Happy AI Path</title>
+    <link rel="canonical" href="https://happyaipath.com/tips.html">
     <meta name="description" content="A curated library of high-performance AI prompts for executives, strategy, coding, and team management. Copy, paste, and refine.">
     <meta name="keywords" content="AI Prompts, ChatGPT Templates, Gemini Prompts, Copilot Prompts, Executive Prompting, Chain of Thought, Zero Shot">
     <meta name="author" content="Jim Perry, Happy AI Path">
@@ -11,10 +12,10 @@
     
     <!-- Open Graph / Social -->
     <meta property="og:type" content="article">
-    <meta property="og:url" content="https://www.happyaipath.com/tips.html">
+    <meta property="og:url" content="https://happyaipath.com/tips.html">
     <meta property="og:title" content="AI Prompting Lab | High-Impact Templates">
     <meta property="og:description" content="Master the art of prompting with our curated library of templates for leaders and teams.">
-    <meta property="og:image" content="https://www.happyaipath.com/HappyAIPath.png">
+    <meta property="og:image" content="https://happyaipath.com/HappyAIPath.png">
 
     <link rel="icon" href="HappyAIPath.png" type="image/png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -33,7 +34,7 @@
       "publisher": {
         "@type": "Organization",
         "name": "Happy AI Path",
-        "logo": "https://www.happyaipath.com/HappyAIPath.png"
+        "logo": "https://happyaipath.com/HappyAIPath.png"
       },
       "hasPart": [
         {


### PR DESCRIPTION
### Motivation
- Standardize site URLs and metadata for SEO and social sharing by moving from the `www` subdomain to the apex `happyaipath.com` domain and ensuring canonical/robots headers are present.

### Description
- Replaced occurrences of `https://www.happyaipath.com` with `https://happyaipath.com` across HTML meta tags, Open Graph/Twitter tags, JSON-LD structured data, `sitemap.xml`, `robots.txt`, and `llms.txt`.
- Added `link rel="canonical"` tags to several pages (including `index.html`, `blog.html`, `contact.html`, `events.html`, `guide.html`, `quiz.html`, `services.html`, and `tips.html`) and inserted `<meta name="robots" content="index, follow">` on key pages to make indexing intent explicit.
- Updated image and logo references in meta and structured data to use the non-www host to keep assets consistent with the canonical domain.

### Testing
- Performed an automated grep-based smoke check (`grep -R "www.happyaipath.com" .`) to verify removal of `www` references and presence of the new `canonical`/`robots` tags, which passed.
- No other automated unit tests applied to these static HTML/content changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1742c821e4832c88996fb029658ab4)